### PR TITLE
Fix GUI acronym expansion, and copyright year

### DIFF
--- a/DesignGUI.texinfo
+++ b/DesignGUI.texinfo
@@ -59,15 +59,15 @@
 @include chapter-07/contents.texinfo
 @c
 @c=====================================
-@c Apprendices
+@c Appendices
 @c=====================================
-@c Copyrighted document used in the booklet
+@c Copyrights used in the booklet
 @include misc/copyrights.texinfo
 @c List of exercises
 @node The Exercises
 @appendix The Exercises
 @listoffloats Exercise
-@c Solutions of exercises
+@c Solutions to exercises
 @include chapter-50/contents.texinfo
 @c List of examples
 @node The Examples

--- a/chapter-01/contents.texinfo
+++ b/chapter-01/contents.texinfo
@@ -2,7 +2,7 @@
 @chapter Introduction
 
 This booklet is a collection of how-to guides for building basic
-@acronym{GUI, Graphic User Interface} with @cuis{} and its Morphic system.
+@acronym{GUIs, Graphical User Interfaces} with @cuis{} and its Morphic system.
 Some chapters, such as @ref{What is a Morph after all?} and @ref{Design a
 GUI application}, present deeper knowledge. Most chapters can be
 read independently to suit the reader's needs.

--- a/chapter-03/contents.texinfo
+++ b/chapter-03/contents.texinfo
@@ -364,7 +364,7 @@ completely dependent on the underlying mathematical models.
 The remaining classes of the kernel morph hierarchy add geometry and visual
 properties. @class{BoxMorph} is the most important one; it is bounded by
 a rectangular extent. It is the root of most sub-morphs used to construct a
-@acronym{GUI, Graphic User Interface}. Indeed, its elements are most often
+@acronym{GUI, Graphical User Interface}. Indeed, its elements are most often
 bounded by a rectangular shape. It allows for significant optimization in
 the rendering of the whole @cuis{} @acronym{GUI}.
 

--- a/chapter-04/contents.texinfo
+++ b/chapter-04/contents.texinfo
@@ -191,7 +191,7 @@ window
    addMorph: colorButton;
    addMorph: statusLabel;
    openInWorld;
-   morphExtent: (300 @@ window layoutMorph minimumExtent y)}
+   morphExtent: (400 @@ window layoutMorph minimumExtent y)}
 
 Once the button is clicked, we request at runtime the menu with the
 appropriate selection of colors from which to pick an answer.

--- a/chapter-05/contents.texinfo
+++ b/chapter-05/contents.texinfo
@@ -44,7 +44,7 @@ names@footnote{The book @emph{Smalltalk with Style} is worth reading to write go
 Smalltalk code.}, and each one with a clearly assigned task as well. Ideally, a method
 should not be longer than 10 lines.
 
-With this practice in mind, when it comes to @acronym{GUI, Graphic User
+With this practice in mind, when it comes to @acronym{GUI, Graphical User
 Interface} application development, there is a well-known design pattern:
 @acronym{MVC, Model View Controller} or its alternative @acronym{MVP, Model View
 Presenter}. In this design, the responsibilities are spread across three

--- a/misc/copying.texinfo
+++ b/misc/copying.texinfo
@@ -3,7 +3,7 @@
 (@value{cuisVersion}), a free and modern implementation of the
 Smalltalk language and environment.
 
-Copyright @copyright{} 2025 @value{writers}
+Copyright @copyright{} 2025-2026 @value{writers}
 @*
 @thanks{}
 @*

--- a/misc/copyrights.texinfo
+++ b/misc/copyrights.texinfo
@@ -1,6 +1,6 @@
-@c Documents avec copyright
-@node Documents Copyright
-@appendix Documents Copyright
+@c Documents with copyright
+@node Copyrights
+@appendix Copyrights
 
 @noindent
 

--- a/misc/settings.texinfo
+++ b/misc/settings.texinfo
@@ -1,7 +1,7 @@
 @documentlanguage en
 @documentencoding UTF-8
 @set bookTitle The Morph Book vol. I
-@set bookSubTitle Design Graphic User Interface
+@set bookSubTitle Designing Graphical User Interfaces
 @set cuisVersion 7.0 or later
 @set writers H. Fernandes
 @settitle @value{bookTitle}
@@ -36,7 +36,7 @@ Cuis-Smalltalk
 
 @macro thanks
 @c Alphabetical list of reviewers
-Thanks to Mark Volkmann to share his examples and chapter on layout.
+Thanks to Mark Volkmann for sharing his examples and chapter on layouts.
 @*
 
 Thanks to Ken Dickey, Thiago da Silva Lino, Stephen Smith for the


### PR DESCRIPTION
Changed term to Graphical User Interface, and added 2026 to the copyright year statement. Adjusted the width of MenuDemo so the result does not cut off the window title. Corrected Appendix A's title to be grammatically correct - allows future copyrights to be added.